### PR TITLE
SCRUM-26: Implement permission system for students and admins

### DIFF
--- a/static/accounts/admin.py
+++ b/static/accounts/admin.py
@@ -1,4 +1,61 @@
 from django.contrib import admin
 from .models import CustomUser
+from django.contrib.auth.admin import UserAdmin
+from .choices import UserTypeChoices
 
-admin.site.register(CustomUser)
+class CustomUserAdmin(UserAdmin):
+    list_display = ('email', 'full_name', 'user_type', 'is_active', 'is_staff')
+    list_filter = ('user_type', 'is_active', 'is_staff')
+    search_fields = ('email', 'full_name', 'phone_number')
+    ordering = ('email',)
+    
+    fieldsets = (
+        (None, {'fields': ('email', 'password')}),
+        ('Personal Info', {'fields': ('full_name', 'phone_number')}),
+        ('Permissions', {'fields': ('user_type', 'is_active', 'is_staff', 'is_superuser')}),
+    )
+    
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('email', 'full_name', 'password1', 'password2', 'user_type'),
+        }),
+    )
+    
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return qs
+        # Students can only see their own user account
+        return qs.filter(id=request.user.id)
+    
+    def has_add_permission(self, request):
+        return request.user.user_type == UserTypeChoices.ADMIN
+    
+    def has_change_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        # Students can only edit their own profile
+        if obj is not None:
+            return obj.id == request.user.id
+        return True
+    
+    def has_delete_permission(self, request, obj=None):
+        # Only admins can delete users
+        return request.user.user_type == UserTypeChoices.ADMIN
+    
+    def has_view_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        # Students can only view their own profile
+        if obj is not None:
+            return obj.id == request.user.id
+        return True
+    
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return ()
+        # Students cannot change their user_type
+        return ('user_type', 'is_staff', 'is_superuser')
+
+admin.site.register(CustomUser, CustomUserAdmin)

--- a/static/appointments/admin.py
+++ b/static/appointments/admin.py
@@ -1,4 +1,37 @@
 from django.contrib import admin
 from .models import Appointment
+from accounts.choices import UserTypeChoices
 
-admin.site.register(Appointment)
+class AppointmentAdmin(admin.ModelAdmin):
+    list_display = ('owner', 'preferred_date', 'preferred_time', 'created_at')
+    list_filter = ('preferred_date', 'created_at')
+    search_fields = ('owner__email', 'owner__full_name')
+    
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return qs
+        return qs.filter(owner=request.user)
+    
+    def has_change_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+    
+    def has_delete_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+        
+    def has_view_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+
+admin.site.register(Appointment, AppointmentAdmin)

--- a/static/blog/admin.py
+++ b/static/blog/admin.py
@@ -1,4 +1,43 @@
 from django.contrib import admin
 from .models import BlogPost
+from accounts.choices import UserTypeChoices
 
-admin.site.register(BlogPost)
+class BlogPostAdmin(admin.ModelAdmin):
+    list_display = ('title', 'owner', 'category', 'created_at', 'updated_at')
+    list_filter = ('category', 'created_at')
+    search_fields = ('title', 'content', 'owner__email', 'owner__full_name')
+    prepopulated_fields = {'slug': ('title',)}
+    
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return qs
+        return qs.filter(owner=request.user)
+    
+    def has_change_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+    
+    def has_delete_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+        
+    def has_view_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+    
+    def save_model(self, request, obj, form, change):
+        if not change:  # If this is a new object
+            obj.owner = request.user
+        super().save_model(request, obj, form, change)
+
+admin.site.register(BlogPost, BlogPostAdmin)

--- a/static/contacts/admin.py
+++ b/static/contacts/admin.py
@@ -1,4 +1,42 @@
 from django.contrib import admin
 from .models import ContactMessage
+from accounts.choices import UserTypeChoices
 
-admin.site.register(ContactMessage)
+class ContactMessageAdmin(admin.ModelAdmin):
+    list_display = ('subject', 'owner', 'sent_at')
+    list_filter = ('sent_at',)
+    search_fields = ('subject', 'message', 'owner__email', 'owner__full_name')
+    
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return qs
+        return qs.filter(owner=request.user)
+    
+    def has_change_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+    
+    def has_delete_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+        
+    def has_view_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+    
+    def save_model(self, request, obj, form, change):
+        if not change:  # If this is a new object
+            obj.owner = request.user
+        super().save_model(request, obj, form, change)
+
+admin.site.register(ContactMessage, ContactMessageAdmin)

--- a/static/courses/admin.py
+++ b/static/courses/admin.py
@@ -1,4 +1,23 @@
 from django.contrib import admin
 from .models import Course
+from accounts.choices import UserTypeChoices
 
-admin.site.register(Course)
+class CourseAdmin(admin.ModelAdmin):
+    list_display = ('title', 'category', 'country', 'price', 'duration_weeks', 'start_date')
+    list_filter = ('category', 'country', 'start_date')
+    search_fields = ('title', 'description', 'category', 'country')
+    
+    def has_add_permission(self, request):
+        return request.user.user_type == UserTypeChoices.ADMIN
+    
+    def has_change_permission(self, request, obj=None):
+        return request.user.user_type == UserTypeChoices.ADMIN
+    
+    def has_delete_permission(self, request, obj=None):
+        return request.user.user_type == UserTypeChoices.ADMIN
+    
+    def has_view_permission(self, request, obj=None):
+        # Everyone can view courses
+        return True
+
+admin.site.register(Course, CourseAdmin)

--- a/static/testimonials/admin.py
+++ b/static/testimonials/admin.py
@@ -1,4 +1,42 @@
 from django.contrib import admin
 from .models import Testimonial
+from accounts.choices import UserTypeChoices
 
-admin.site.register(Testimonial)
+class TestimonialAdmin(admin.ModelAdmin):
+    list_display = ('owner', 'university', 'country', 'created_at')
+    list_filter = ('country', 'created_at')
+    search_fields = ('owner__email', 'owner__full_name', 'university', 'story')
+    
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return qs
+        return qs.filter(owner=request.user)
+    
+    def has_change_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+    
+    def has_delete_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+        
+    def has_view_permission(self, request, obj=None):
+        if request.user.user_type == UserTypeChoices.ADMIN:
+            return True
+        if obj is not None:
+            return obj.owner == request.user
+        return True
+    
+    def save_model(self, request, obj, form, change):
+        if not change:  # If this is a new object
+            obj.owner = request.user
+        super().save_model(request, obj, form, change)
+
+admin.site.register(Testimonial, TestimonialAdmin)


### PR DESCRIPTION
1. For students:
* Can only see and edit their own profile
* Can only view, modify, and delete content they own (appointments, blog posts, contact messages, testimonials)
* Can view all courses but cannot add, modify, or delete them
* Cannot add or delete other users
1. For admins:
* Have full access to all objects in the system
* Can manage all users, including creating new admin users
* Can manage all content regardless of ownership
1. Implementation details:
* Used Django's permission methods (has_view_permission, has_change_permission, etc.)
* Customized get_queryset to filter visible objects based on user type
* Added save_model to automatically set the owner when students create content
* Set appropriate read-only fields for students to prevent them from changing critical permissions
* Added useful list displays and filters for better admin usability